### PR TITLE
fix(get_charms): fix clone() for directories outside current dir

### DIFF
--- a/tools/get_charms.py
+++ b/tools/get_charms.py
@@ -54,7 +54,7 @@ async def clone(dest_folder: pathlib.Path, name: str, repository: str, branch: s
     clone = await asyncio.create_subprocess_exec(
         *args,
         repository,
-        cwd=dest_folder.parent.name,
+        cwd=dest_folder.parent,
     )
     await clone.wait()
     if clone.returncode != 0:


### PR DESCRIPTION
Previously clone() failed if you provided a path that's not in the current dir, for example: `--cache-folder /some/abs/path` or `--cache-folder ../charms`.

This makes it work.