### PR TITLE
chore: bump python since code uses asyncio.TaskGroup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,11 @@ name = "charm-analysis"
 version = "1.0.0b1"
 description = "Tool to analyse charm code en masse"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = [
     "click>=8.1.7",
     "httpx>=0.27.2",
     "packaging>=24.1",
     "pyyaml>=6.0.2",
     "rich>=13.8.0",
-    "tomli>=2.0 ; python_full_version < '3.11'",
 ]


### PR DESCRIPTION
Older pythons understandably fail with

```py
  File "tools/get_charms.py", line 77, in process_input
    async with asyncio.TaskGroup() as tg:
AttributeError: module 'asyncio' has no attribute 'TaskGroup'
```

bumping python to 3.11 and thus removing tomli dep