### PR TITLE
feat: add a script that checks whether action parameters are being used when not defined

### DIFF
--- a/tools/summarise_tests.py
+++ b/tools/summarise_tests.py
@@ -94,10 +94,6 @@ def main(cache_folder):
                 test_frameworks["pytest"] += 1
             if "pytest_operator.plugin" in repo_test_imports:
                 test_frameworks["pytest_operator"] += 1
-            if "juju" in repo_test_imports:
-                test_frameworks["python-libjuju"] += 1
-            if "jubilant" in repo_test_imports:
-                test_frameworks["jubilant"] += 1
             if "zaza" in repo_test_imports:
                 # TODO: I'm not sure if this is always required - it seems like
                 # there is always a tests.yaml file, but not at the top level,
@@ -136,7 +132,6 @@ def report(uses_tox, total, test_imports, tox_environments, tox_static_environme
             ("Scenario", test_imports["scenario"]),
             ("pytest-operator", test_imports["pytest_operator.plugin"]),
             ("zaza", test_imports["zaza"]),
-            ("juju", test_imports["juju"]),
         ),
     )
     console.print(table)

--- a/tools/summarise_tests.py
+++ b/tools/summarise_tests.py
@@ -94,6 +94,10 @@ def main(cache_folder):
                 test_frameworks["pytest"] += 1
             if "pytest_operator.plugin" in repo_test_imports:
                 test_frameworks["pytest_operator"] += 1
+            if "juju" in repo_test_imports:
+                test_frameworks["python-libjuju"] += 1
+            if "jubilant" in repo_test_imports:
+                test_frameworks["jubilant"] += 1
             if "zaza" in repo_test_imports:
                 # TODO: I'm not sure if this is always required - it seems like
                 # there is always a tests.yaml file, but not at the top level,
@@ -132,6 +136,7 @@ def report(uses_tox, total, test_imports, tox_environments, tox_static_environme
             ("Scenario", test_imports["scenario"]),
             ("pytest-operator", test_imports["pytest_operator.plugin"]),
             ("zaza", test_imports["zaza"]),
+            ("juju", test_imports["juju"]),
         ),
     )
     console.print(table)

--- a/tools/validate_action_params.py
+++ b/tools/validate_action_params.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+"""Validate that event.params accesses match action definitions.
+
+This script checks that all parameters accessed via event.params in charm
+action handlers are properly defined in actions.yaml or charmcraft.yaml.
+"""
+
+import ast
+import csv
+import logging
+import pathlib
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import click
+import rich.console
+import rich.logging
+import rich.table
+import yaml
+
+from helpers import iter_repositories
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ParamDef:
+    """Definition of an action parameter."""
+    name: str
+    type: str | None = None
+    required: bool = False
+    default: Any | None = None
+
+
+@dataclass
+class ActionDefinition:
+    """Definition of a charm action."""
+    name: str
+    params: dict[str, ParamDef] = field(default_factory=dict)
+    required_params: set[str] = field(default_factory=set)
+    source_file: str = ""
+
+
+@dataclass
+class ParamAccess:
+    """A parameter access in code."""
+    param_name: str | None  # None for spread operator
+    access_type: Literal['subscript', 'get', 'spread']
+    line_number: int
+    is_safe: bool  # True for .get(), False for []
+
+
+@dataclass
+class Violation:
+    """A validation error."""
+    action_name: str
+    handler_name: str
+    param_name: str
+    access_type: str
+    line_number: int
+    file_path: str
+    message: str
+
+
+@dataclass
+class Warning:
+    """A validation warning."""
+    action_name: str
+    param_name: str
+    line_number: int
+    file_path: str
+    message: str
+
+
+@dataclass
+class ManualReview:
+    """An item flagged for manual review."""
+    action_name: str
+    line_number: int
+    file_path: str
+    reason: str
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating a charm."""
+    charm_name: str
+    charm_path: pathlib.Path
+    total_actions: int
+    violations: list[Violation] = field(default_factory=list)
+    warnings: list[Warning] = field(default_factory=list)
+    manual_review: list[ManualReview] = field(default_factory=list)
+
+
+def load_action_definitions(repo: pathlib.Path) -> dict[str, ActionDefinition]:
+    """Load action definitions from actions.yaml or charmcraft.yaml.
+
+    Args:
+        repo: Path to the charm repository
+
+    Returns:
+        Dictionary mapping action-name → ActionDefinition
+    """
+    actions = {}
+
+    # Try actions.yaml first (standalone file)
+    actions_yaml = repo / "actions.yaml"
+    if actions_yaml.exists():
+        try:
+            with actions_yaml.open() as f:
+                actions_data = yaml.safe_load(f) or {}
+
+            for action_name, action_spec in actions_data.items():
+                if not isinstance(action_spec, dict):
+                    continue
+
+                params_dict = {}
+                params_section = action_spec.get("params") or action_spec.get("properties") or {}
+                required_list = action_spec.get("required", [])
+
+                for param_name, param_spec in params_section.items():
+                    if isinstance(param_spec, dict):
+                        params_dict[param_name] = ParamDef(
+                            name=param_name,
+                            type=param_spec.get("type"),
+                            required=param_name in required_list,
+                            default=param_spec.get("default"),
+                        )
+                    else:
+                        params_dict[param_name] = ParamDef(name=param_name)
+
+                actions[action_name] = ActionDefinition(
+                    name=action_name,
+                    params=params_dict,
+                    required_params=set(required_list),
+                    source_file="actions.yaml",
+                )
+        except Exception as e:
+            logger.warning(f"Failed to parse {actions_yaml}: {e}")
+
+    # Try charmcraft.yaml if no actions.yaml or to augment it
+    charmcraft_yaml = repo / "charmcraft.yaml"
+    if charmcraft_yaml.exists():
+        try:
+            with charmcraft_yaml.open() as f:
+                charmcraft_data = yaml.safe_load(f) or {}
+
+            actions_data = charmcraft_data.get("actions", {})
+            for action_name, action_spec in actions_data.items():
+                # Skip if already loaded from actions.yaml
+                if action_name in actions:
+                    continue
+
+                if not isinstance(action_spec, dict):
+                    continue
+
+                params_dict = {}
+                params_section = action_spec.get("params") or action_spec.get("properties") or {}
+                required_list = action_spec.get("required", [])
+
+                for param_name, param_spec in params_section.items():
+                    if isinstance(param_spec, dict):
+                        params_dict[param_name] = ParamDef(
+                            name=param_name,
+                            type=param_spec.get("type"),
+                            required=param_name in required_list,
+                            default=param_spec.get("default"),
+                        )
+                    else:
+                        params_dict[param_name] = ParamDef(name=param_name)
+
+                actions[action_name] = ActionDefinition(
+                    name=action_name,
+                    params=params_dict,
+                    required_params=set(required_list),
+                    source_file="charmcraft.yaml",
+                )
+        except Exception as e:
+            logger.warning(f"Failed to parse {charmcraft_yaml}: {e}")
+
+    return actions
+
+
+def _normalize_action_name(event_name: str) -> str:
+    """Convert event name to action name.
+
+    Examples:
+        create_oauth_client_action → create-oauth-client
+        get_password_action → get-password
+    """
+    # Remove _action suffix
+    if event_name.endswith("_action"):
+        event_name = event_name[:-7]
+
+    # Convert underscores to hyphens
+    return event_name.replace("_", "-")
+
+
+def find_action_handlers(module: pathlib.Path) -> dict[str, str]:
+    """Find action event handlers and their action names.
+
+    Args:
+        module: Path to Python file
+
+    Returns:
+        Dictionary mapping handler_method_name → action-name
+    """
+    handlers = {}
+
+    try:
+        with module.open() as f:
+            tree = ast.parse(f.read())
+    except Exception as e:
+        logger.debug(f"Failed to parse {module}: {e}")
+        return handlers
+
+    # Find framework.observe calls for actions
+    # Pattern: self.framework.observe(self.on.XXX_action, handler_method)
+    for node in ast.walk(tree):
+        if (
+            not isinstance(node, ast.Call)
+            or not isinstance(node.func, ast.Attribute)
+            or node.func.attr != "observe"
+            or len(node.args) < 2
+        ):
+            continue
+
+        # First arg: self.on.XXX_action
+        event_arg = node.args[0]
+        event_name = None
+
+        if isinstance(event_arg, ast.Attribute) and hasattr(event_arg, 'attr'):
+            event_name = event_arg.attr
+        elif isinstance(event_arg, ast.Name):
+            event_name = event_arg.id
+        elif (
+            isinstance(event_arg, ast.Call)
+            and hasattr(event_arg.func, "id")
+            and event_arg.func.id == "getattr"
+            and len(event_arg.args) >= 2
+        ):
+            if isinstance(event_arg.args[1], ast.Constant):
+                event_name = event_arg.args[1].value
+
+        # Second arg: handler method
+        handler_arg = node.args[1]
+        handler_name = None
+
+        if isinstance(handler_arg, ast.Attribute):
+            handler_name = handler_arg.attr
+        elif isinstance(handler_arg, ast.Name):
+            handler_name = handler_arg.id
+
+        # Only track if it looks like an action event
+        if event_name and handler_name and "_action" in event_name:
+            action_name = _normalize_action_name(event_name)
+            handlers[handler_name] = action_name
+
+    return handlers
+
+
+def _find_method_by_name(tree: ast.AST, method_name: str) -> ast.FunctionDef | None:
+    """Find a method definition by name in an AST."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == method_name:
+            return node
+    return None
+
+
+def extract_event_params(module: pathlib.Path, handler_name: str) -> list[ParamAccess]:
+    """Extract event.params accesses from a specific handler method.
+
+    Args:
+        module: Path to Python file
+        handler_name: Name of the handler method
+
+    Returns:
+        List of ParamAccess objects
+    """
+    accesses = []
+
+    try:
+        with module.open() as f:
+            tree = ast.parse(f.read())
+    except Exception as e:
+        logger.debug(f"Failed to parse {module}: {e}")
+        return accesses
+
+    # Find the handler method
+    handler_method = _find_method_by_name(tree, handler_name)
+    if not handler_method:
+        logger.debug(f"Handler {handler_name} not found in {module}")
+        return accesses
+
+    # Walk the handler method's AST
+    for node in ast.walk(handler_method):
+        # Pattern 1: event.params["key"] or event.params['key']
+        if isinstance(node, ast.Subscript):
+            # Check if this is event.params[...]
+            if (
+                isinstance(node.value, ast.Attribute)
+                and node.value.attr == "params"
+                and isinstance(node.slice, ast.Constant)
+                and isinstance(node.slice.value, str)
+            ):
+                accesses.append(ParamAccess(
+                    param_name=node.slice.value,
+                    access_type='subscript',
+                    line_number=node.lineno,
+                    is_safe=False,
+                ))
+
+        # Pattern 2: event.params.get("key")
+        # Pattern 3: **event.params (spread operator)
+        elif isinstance(node, ast.Call):
+            # Pattern 2: .get() method
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get"
+                and isinstance(node.func.value, ast.Attribute)
+                and node.func.value.attr == "params"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                accesses.append(ParamAccess(
+                    param_name=node.args[0].value,
+                    access_type='get',
+                    line_number=node.lineno,
+                    is_safe=True,
+                ))
+
+            # Pattern 3: Spread operator in keyword arguments
+            for keyword in node.keywords:
+                if (
+                    keyword.arg is None  # **kwargs pattern
+                    and isinstance(keyword.value, ast.Attribute)
+                    and keyword.value.attr == "params"
+                ):
+                    accesses.append(ParamAccess(
+                        param_name=None,
+                        access_type='spread',
+                        line_number=node.lineno,
+                        is_safe=True,
+                    ))
+
+    return accesses
+
+
+def validate_charm(repo: pathlib.Path, entry: pathlib.Path) -> tuple[ValidationResult | None, str | None]:
+    """Validate action parameter usage for a single charm.
+
+    Args:
+        repo: Path to charm repository
+        entry: Path to charm entry point (src/charm.py)
+
+    Returns:
+        Tuple of (ValidationResult or None, skip_reason or None)
+        skip_reason is one of: "no_actions", "no_handlers", or None if not skipped
+    """
+    charm_name = repo.name
+
+    # Load action definitions
+    action_defs = load_action_definitions(repo)
+    if not action_defs:
+        return None, "no_actions"
+
+    # Find all Python files to scan (src/ and lib/)
+    python_files = []
+
+    # Add main charm entry
+    if entry.exists():
+        python_files.append(entry)
+
+    # Add lib files
+    lib_dir = repo / "lib"
+    if lib_dir.exists():
+        for py_file in lib_dir.rglob("*.py"):
+            # Skip __pycache__ and test files
+            if "__pycache__" not in str(py_file) and "test" not in py_file.name.lower():
+                python_files.append(py_file)
+
+    # Find action handlers across all files
+    all_handlers = {}
+    for py_file in python_files:
+        handlers = find_action_handlers(py_file)
+        for handler_name, action_name in handlers.items():
+            # Store both handler name and file path
+            all_handlers[handler_name] = (action_name, py_file)
+
+    if not all_handlers:
+        logger.debug(f"No action handlers found in {charm_name}")
+        return None, "no_handlers"
+
+    result = ValidationResult(
+        charm_name=charm_name,
+        charm_path=repo,
+        total_actions=len(action_defs),
+    )
+
+    # Validate each handler
+    for handler_name, (action_name, py_file) in all_handlers.items():
+        # Check if action is defined
+        if action_name not in action_defs:
+            result.violations.append(Violation(
+                action_name=action_name,
+                handler_name=handler_name,
+                param_name="N/A",
+                access_type="N/A",
+                line_number=0,
+                file_path=str(py_file.relative_to(repo)),
+                message=f"Handler exists but action '{action_name}' not defined in YAML",
+            ))
+            continue
+
+        action_def = action_defs[action_name]
+        defined_params = set(action_def.params.keys())
+
+        # Extract param accesses
+        param_accesses = extract_event_params(py_file, handler_name)
+
+        for access in param_accesses:
+            if access.access_type == 'spread':
+                # Flag for manual review
+                result.manual_review.append(ManualReview(
+                    action_name=action_name,
+                    line_number=access.line_number,
+                    file_path=str(py_file.relative_to(repo)),
+                    reason="Spread operator (**event.params) - cannot validate statically",
+                ))
+            elif access.param_name:
+                # Check if parameter is defined
+                if access.param_name not in defined_params:
+                    if access.access_type == 'subscript':
+                        # Error for direct access
+                        result.violations.append(Violation(
+                            action_name=action_name,
+                            handler_name=handler_name,
+                            param_name=access.param_name,
+                            access_type='[]',
+                            line_number=access.line_number,
+                            file_path=str(py_file.relative_to(repo)),
+                            message=f"Parameter '{access.param_name}' accessed but not defined in {action_def.source_file}",
+                        ))
+                    elif access.access_type == 'get':
+                        # Warning for .get() access
+                        result.warnings.append(Warning(
+                            action_name=action_name,
+                            param_name=access.param_name,
+                            line_number=access.line_number,
+                            file_path=str(py_file.relative_to(repo)),
+                            message=f"Parameter '{access.param_name}' accessed via .get() but not defined in {action_def.source_file}",
+                        ))
+
+    return result, None
+
+
+def report(results: list[ValidationResult], console: rich.console.Console, skip_stats: dict[str, int] | None = None):
+    """Generate rich console report.
+
+    Args:
+        results: List of validation results
+        console: Rich console for output
+    """
+    # Calculate summary statistics
+    total_charms = len(results)
+    charms_with_violations = sum(1 for r in results if r.violations)
+    charms_with_warnings = sum(1 for r in results if r.warnings)
+    total_violations = sum(len(r.violations) for r in results)
+    total_warnings = sum(len(r.warnings) for r in results)
+    total_manual_review = sum(len(r.manual_review) for r in results)
+
+    # Summary
+    console.print("\n[bold]Action Parameter Validation Report[/bold]")
+    console.print("═" * 50)
+    console.print(f"\n[bold]Summary[/bold]")
+
+    # Show skip statistics if available
+    if skip_stats:
+        total_processed = skip_stats.get("total", 0)
+        console.print(f"Total charms processed: {total_processed}")
+        console.print(f"Charms analyzed (with actions and handlers): {total_charms}")
+
+        # Show skipped charms breakdown
+        no_actions = skip_stats.get("no_actions", 0)
+        no_handlers = skip_stats.get("no_handlers", 0)
+        total_skipped = no_actions + no_handlers
+
+        if total_skipped > 0:
+            console.print(f"\n[dim]Skipped charms: {total_skipped}[/dim]")
+            if no_actions > 0:
+                console.print(f"  [dim]- No action definitions: {no_actions}[/dim]")
+            if no_handlers > 0:
+                console.print(f"  [dim]- Actions defined but no handlers: {no_handlers}[/dim]")
+        console.print()
+    else:
+        console.print(f"Total charms analyzed: {total_charms}")
+
+    console.print(f"Charms with violations: {charms_with_violations}")
+    console.print(f"Charms with warnings: {charms_with_warnings}")
+    console.print(f"Total violations (errors): {total_violations}")
+    console.print(f"Total warnings: {total_warnings}")
+    console.print(f"Total flagged for manual review: {total_manual_review}")
+
+    # Violations table
+    if total_violations > 0:
+        console.print("\n[bold red]ERRORS: Parameters accessed with [] but not defined[/bold red]")
+        console.print("═" * 80)
+
+        table = rich.table.Table(show_header=True, header_style="bold red")
+        table.add_column("Charm", style="cyan")
+        table.add_column("Action", style="yellow")
+        table.add_column("Parameter", style="magenta")
+        table.add_column("Location", style="green")
+
+        for result in results:
+            for v in result.violations:
+                table.add_row(
+                    result.charm_name,
+                    v.action_name,
+                    v.param_name,
+                    f"{v.file_path}:{v.line_number}",
+                )
+
+        console.print(table)
+
+    # Warnings table
+    if total_warnings > 0:
+        console.print("\n[bold yellow]WARNINGS: Parameters accessed with .get() but not defined[/bold yellow]")
+        console.print("═" * 80)
+
+        table = rich.table.Table(show_header=True, header_style="bold yellow")
+        table.add_column("Charm", style="cyan")
+        table.add_column("Action", style="yellow")
+        table.add_column("Parameter", style="magenta")
+        table.add_column("Location", style="green")
+
+        for result in results:
+            for w in result.warnings:
+                table.add_row(
+                    result.charm_name,
+                    w.action_name,
+                    w.param_name,
+                    f"{w.file_path}:{w.line_number}",
+                )
+
+        console.print(table)
+
+    # Manual review table
+    if total_manual_review > 0:
+        console.print("\n[bold blue]MANUAL REVIEW: Spread operator usage[/bold blue]")
+        console.print("═" * 80)
+
+        table = rich.table.Table(show_header=True, header_style="bold blue")
+        table.add_column("Charm", style="cyan")
+        table.add_column("Action", style="yellow")
+        table.add_column("Location", style="green")
+        table.add_column("Reason", style="white")
+
+        for result in results:
+            for m in result.manual_review:
+                table.add_row(
+                    result.charm_name,
+                    m.action_name,
+                    f"{m.file_path}:{m.line_number}",
+                    m.reason,
+                )
+
+        console.print(table)
+
+    # Success message if no issues
+    if total_violations == 0 and total_warnings == 0:
+        console.print("\n[bold green]✓ No validation issues found![/bold green]")
+
+
+@click.command()
+@click.option("--cache-folder", default=".cache", help="Path to .cache folder")
+@click.option("--strict", is_flag=True, help="Treat warnings as errors")
+@click.option("--output-csv", type=click.File('w'), help="Also output CSV for further analysis")
+@click.option("--verbose", is_flag=True, help="Show detailed logging")
+def main(cache_folder, strict, output_csv, verbose):
+    """Validate action parameter usage across all charms."""
+    # Setup logging
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(message)s",
+        handlers=[rich.logging.RichHandler(rich_tracebacks=True)],
+    )
+
+    console = rich.console.Console()
+    cache_path = pathlib.Path(cache_folder)
+
+    if not cache_path.exists():
+        console.print(f"[red]Error: Cache folder {cache_folder} does not exist[/red]")
+        return 1
+
+    console.print(f"[bold]Analyzing charms in {cache_folder}...[/bold]")
+
+    results = []
+    skip_stats = {
+        "total": 0,
+        "no_actions": 0,
+        "no_handlers": 0,
+    }
+
+    for repo in iter_repositories(cache_path):
+        # Find charm entry point
+        entry = repo / "src" / "charm.py"
+        if not entry.exists():
+            continue
+
+        skip_stats["total"] += 1
+        result, skip_reason = validate_charm(repo, entry)
+
+        if skip_reason:
+            skip_stats[skip_reason] = skip_stats.get(skip_reason, 0) + 1
+        elif result:
+            results.append(result)
+
+    # Generate report
+    report(results, console, skip_stats)
+
+    # Output CSV if requested
+    if output_csv:
+        writer = csv.writer(output_csv)
+        writer.writerow(["charm", "action", "parameter", "access_type", "line", "file", "severity", "defined_params"])
+
+        for result in results:
+            for v in result.violations:
+                writer.writerow([
+                    result.charm_name,
+                    v.action_name,
+                    v.param_name,
+                    v.access_type,
+                    v.line_number,
+                    v.file_path,
+                    "error",
+                    "",  # Could add defined params here
+                ])
+
+            for w in result.warnings:
+                writer.writerow([
+                    result.charm_name,
+                    w.action_name,
+                    w.param_name,
+                    ".get()",
+                    w.line_number,
+                    w.file_path,
+                    "warning",
+                    "",
+                ])
+
+        console.print(f"\n[green]CSV output written to {output_csv.name}[/green]")
+
+    # Return exit code
+    total_violations = sum(len(r.violations) for r in results)
+    total_warnings = sum(len(r.warnings) for r in results)
+
+    if strict and (total_violations > 0 or total_warnings > 0):
+        return 1
+    elif total_violations > 0:
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/tools/validate_action_params.py
+++ b/tools/validate_action_params.py
@@ -381,12 +381,12 @@ def validate_charm(repo: pathlib.Path, entry: pathlib.Path) -> tuple[ValidationR
                 python_files.append(py_file)
 
     # Find action handlers across all files
-    all_handlers = {}
+    all_handlers = []
     for py_file in python_files:
         handlers = find_action_handlers(py_file)
         for handler_name, action_name in handlers.items():
-            # Store both handler name and file path
-            all_handlers[handler_name] = (action_name, py_file)
+            # Store handler name, action name, and file path
+            all_handlers.append((handler_name, action_name, py_file))
 
     if not all_handlers:
         logger.debug(f"No action handlers found in {charm_name}")
@@ -399,7 +399,7 @@ def validate_charm(repo: pathlib.Path, entry: pathlib.Path) -> tuple[ValidationR
     )
 
     # Validate each handler
-    for handler_name, (action_name, py_file) in all_handlers.items():
+    for handler_name, action_name, py_file in all_handlers:
         # Check if action is defined
         if action_name not in action_defs:
             result.violations.append(Violation(

--- a/tools/validate_action_params.py
+++ b/tools/validate_action_params.py
@@ -665,4 +665,4 @@ def main(cache_folder, strict, output_csv, verbose):
 
 
 if __name__ == "__main__":
-    exit(main())
+    main()

--- a/tools/validate_action_params.py
+++ b/tools/validate_action_params.py
@@ -38,6 +38,7 @@ class ActionDefinition:
     name: str
     params: dict[str, ParamDef] = field(default_factory=dict)
     required_params: set[str] = field(default_factory=set)
+    additional_properties: bool | None = None  # None means not explicitly set in YAML
     source_file: str = ""
 
 
@@ -51,6 +52,15 @@ class ParamAccess:
 
 
 @dataclass
+class HandlerInfo:
+    """Information about a discovered action handler."""
+    handler_name: str
+    action_name: str
+    observe_file: pathlib.Path
+    is_self_method: bool  # True if observed as self.handler (vs. bare function)
+
+
+@dataclass
 class Violation:
     """A validation error."""
     action_name: str
@@ -60,6 +70,7 @@ class Violation:
     line_number: int
     file_path: str
     message: str
+    additional_properties: bool | None = None
 
 
 @dataclass
@@ -70,6 +81,7 @@ class Warning:
     line_number: int
     file_path: str
     message: str
+    additional_properties: bool | None = None
 
 
 @dataclass
@@ -103,6 +115,34 @@ def load_action_definitions(repo: pathlib.Path) -> dict[str, ActionDefinition]:
     """
     actions = {}
 
+    def _parse_action(action_name: str, action_spec: dict, source_file: str) -> ActionDefinition | None:
+        if not isinstance(action_spec, dict):
+            return None
+
+        params_dict = {}
+        params_section = action_spec.get("params") or action_spec.get("properties") or {}
+        required_list = action_spec.get("required", [])
+        additional_properties = action_spec.get("additionalProperties")  # None if not set in YAML
+
+        for param_name, param_spec in params_section.items():
+            if isinstance(param_spec, dict):
+                params_dict[param_name] = ParamDef(
+                    name=param_name,
+                    type=param_spec.get("type"),
+                    required=param_name in required_list,
+                    default=param_spec.get("default"),
+                )
+            else:
+                params_dict[param_name] = ParamDef(name=param_name)
+
+        return ActionDefinition(
+            name=action_name,
+            params=params_dict,
+            required_params=set(required_list),
+            additional_properties=additional_properties,
+            source_file=source_file,
+        )
+
     # Try actions.yaml first (standalone file)
     actions_yaml = repo / "actions.yaml"
     if actions_yaml.exists():
@@ -111,30 +151,9 @@ def load_action_definitions(repo: pathlib.Path) -> dict[str, ActionDefinition]:
                 actions_data = yaml.safe_load(f) or {}
 
             for action_name, action_spec in actions_data.items():
-                if not isinstance(action_spec, dict):
-                    continue
-
-                params_dict = {}
-                params_section = action_spec.get("params") or action_spec.get("properties") or {}
-                required_list = action_spec.get("required", [])
-
-                for param_name, param_spec in params_section.items():
-                    if isinstance(param_spec, dict):
-                        params_dict[param_name] = ParamDef(
-                            name=param_name,
-                            type=param_spec.get("type"),
-                            required=param_name in required_list,
-                            default=param_spec.get("default"),
-                        )
-                    else:
-                        params_dict[param_name] = ParamDef(name=param_name)
-
-                actions[action_name] = ActionDefinition(
-                    name=action_name,
-                    params=params_dict,
-                    required_params=set(required_list),
-                    source_file="actions.yaml",
-                )
+                action_def = _parse_action(action_name, action_spec, "actions.yaml")
+                if action_def:
+                    actions[action_name] = action_def
         except Exception as e:
             logger.warning(f"Failed to parse {actions_yaml}: {e}")
 
@@ -150,31 +169,9 @@ def load_action_definitions(repo: pathlib.Path) -> dict[str, ActionDefinition]:
                 # Skip if already loaded from actions.yaml
                 if action_name in actions:
                     continue
-
-                if not isinstance(action_spec, dict):
-                    continue
-
-                params_dict = {}
-                params_section = action_spec.get("params") or action_spec.get("properties") or {}
-                required_list = action_spec.get("required", [])
-
-                for param_name, param_spec in params_section.items():
-                    if isinstance(param_spec, dict):
-                        params_dict[param_name] = ParamDef(
-                            name=param_name,
-                            type=param_spec.get("type"),
-                            required=param_name in required_list,
-                            default=param_spec.get("default"),
-                        )
-                    else:
-                        params_dict[param_name] = ParamDef(name=param_name)
-
-                actions[action_name] = ActionDefinition(
-                    name=action_name,
-                    params=params_dict,
-                    required_params=set(required_list),
-                    source_file="charmcraft.yaml",
-                )
+                action_def = _parse_action(action_name, action_spec, "charmcraft.yaml")
+                if action_def:
+                    actions[action_name] = action_def
         except Exception as e:
             logger.warning(f"Failed to parse {charmcraft_yaml}: {e}")
 
@@ -196,16 +193,16 @@ def _normalize_action_name(event_name: str) -> str:
     return event_name.replace("_", "-")
 
 
-def find_action_handlers(module: pathlib.Path) -> dict[str, str]:
+def find_action_handlers(module: pathlib.Path) -> list[HandlerInfo]:
     """Find action event handlers and their action names.
 
     Args:
         module: Path to Python file
 
     Returns:
-        Dictionary mapping handler_method_name → action-name
+        List of HandlerInfo objects for each framework.observe() call found
     """
-    handlers = {}
+    handlers = []
 
     try:
         with module.open() as f:
@@ -245,16 +242,28 @@ def find_action_handlers(module: pathlib.Path) -> dict[str, str]:
         # Second arg: handler method
         handler_arg = node.args[1]
         handler_name = None
+        is_self_method = False
 
         if isinstance(handler_arg, ast.Attribute):
             handler_name = handler_arg.attr
+            # Check if it's self.<method>
+            is_self_method = (
+                isinstance(handler_arg.value, ast.Name)
+                and handler_arg.value.id == "self"
+            )
         elif isinstance(handler_arg, ast.Name):
             handler_name = handler_arg.id
+            is_self_method = False
 
         # Only track if it looks like an action event
         if event_name and handler_name and "_action" in event_name:
             action_name = _normalize_action_name(event_name)
-            handlers[handler_name] = action_name
+            handlers.append(HandlerInfo(
+                handler_name=handler_name,
+                action_name=action_name,
+                observe_file=module,
+                is_self_method=is_self_method,
+            ))
 
     return handlers
 
@@ -267,7 +276,7 @@ def _find_method_by_name(tree: ast.AST, method_name: str) -> ast.FunctionDef | N
     return None
 
 
-def extract_event_params(module: pathlib.Path, handler_name: str) -> list[ParamAccess]:
+def extract_event_params(module: pathlib.Path, handler_name: str) -> tuple[list[ParamAccess], bool]:
     """Extract event.params accesses from a specific handler method.
 
     Args:
@@ -275,7 +284,7 @@ def extract_event_params(module: pathlib.Path, handler_name: str) -> list[ParamA
         handler_name: Name of the handler method
 
     Returns:
-        List of ParamAccess objects
+        Tuple of (list of ParamAccess objects, bool indicating if handler was found)
     """
     accesses = []
 
@@ -284,22 +293,38 @@ def extract_event_params(module: pathlib.Path, handler_name: str) -> list[ParamA
             tree = ast.parse(f.read())
     except Exception as e:
         logger.debug(f"Failed to parse {module}: {e}")
-        return accesses
+        return accesses, False
 
     # Find the handler method
     handler_method = _find_method_by_name(tree, handler_name)
     if not handler_method:
         logger.debug(f"Handler {handler_name} not found in {module}")
-        return accesses
+        return accesses, False
+
+    # Detect the event parameter name from the handler signature.
+    # Handler is typically: def handler(self, event) or def handler(event)
+    event_param_name = None
+    args = handler_method.args.args
+    if len(args) >= 2:
+        # self is first arg, event is second
+        event_param_name = args[1].arg
+    elif len(args) == 1:
+        event_param_name = args[0].arg
+
+    if not event_param_name:
+        logger.debug(f"Could not detect event parameter name for {handler_name} in {module}")
+        return accesses, True
 
     # Walk the handler method's AST
     for node in ast.walk(handler_method):
         # Pattern 1: event.params["key"] or event.params['key']
         if isinstance(node, ast.Subscript):
-            # Check if this is event.params[...]
+            # Check if this is <event_param>.params[...]
             if (
                 isinstance(node.value, ast.Attribute)
                 and node.value.attr == "params"
+                and isinstance(node.value.value, ast.Name)
+                and node.value.value.id == event_param_name
                 and isinstance(node.slice, ast.Constant)
                 and isinstance(node.slice.value, str)
             ):
@@ -319,6 +344,8 @@ def extract_event_params(module: pathlib.Path, handler_name: str) -> list[ParamA
                 and node.func.attr == "get"
                 and isinstance(node.func.value, ast.Attribute)
                 and node.func.value.attr == "params"
+                and isinstance(node.func.value.value, ast.Name)
+                and node.func.value.value.id == event_param_name
                 and node.args
                 and isinstance(node.args[0], ast.Constant)
                 and isinstance(node.args[0].value, str)
@@ -336,6 +363,8 @@ def extract_event_params(module: pathlib.Path, handler_name: str) -> list[ParamA
                     keyword.arg is None  # **kwargs pattern
                     and isinstance(keyword.value, ast.Attribute)
                     and keyword.value.attr == "params"
+                    and isinstance(keyword.value.value, ast.Name)
+                    and keyword.value.value.id == event_param_name
                 ):
                     accesses.append(ParamAccess(
                         param_name=None,
@@ -344,15 +373,14 @@ def extract_event_params(module: pathlib.Path, handler_name: str) -> list[ParamA
                         is_safe=True,
                     ))
 
-    return accesses
+    return accesses, True
 
 
-def validate_charm(repo: pathlib.Path, entry: pathlib.Path) -> tuple[ValidationResult | None, str | None]:
+def validate_charm(repo: pathlib.Path) -> tuple[ValidationResult | None, str | None]:
     """Validate action parameter usage for a single charm.
 
     Args:
         repo: Path to charm repository
-        entry: Path to charm entry point (src/charm.py)
 
     Returns:
         Tuple of (ValidationResult or None, skip_reason or None)
@@ -365,28 +393,28 @@ def validate_charm(repo: pathlib.Path, entry: pathlib.Path) -> tuple[ValidationR
     if not action_defs:
         return None, "no_actions"
 
-    # Find all Python files to scan (src/ and lib/)
-    python_files = []
-
-    # Add main charm entry
-    if entry.exists():
-        python_files.append(entry)
-
-    # Add lib files
+    # Find all Python files to scan.
+    # src/**/*.py is scanned for both observe() calls and handler definitions.
+    # lib/**/*.py is scanned for observe() calls (e.g. charm libraries).
+    src_files = sorted(repo.glob("src/**/*.py"))
     lib_dir = repo / "lib"
+    lib_files = []
     if lib_dir.exists():
-        for py_file in lib_dir.rglob("*.py"):
-            # Skip __pycache__ and test files
-            if "__pycache__" not in str(py_file) and "test" not in py_file.name.lower():
-                python_files.append(py_file)
+        lib_files = [
+            f for f in lib_dir.rglob("*.py")
+            if "__pycache__" not in str(f) and "test" not in f.name.lower()
+        ]
+    all_python_files = src_files + lib_files
 
-    # Find action handlers across all files
-    all_handlers = []
-    for py_file in python_files:
-        handlers = find_action_handlers(py_file)
-        for handler_name, action_name in handlers.items():
-            # Store handler name, action name, and file path
-            all_handlers.append((handler_name, action_name, py_file))
+    # Find action handlers across all files, deduplicating by (handler_name, action_name).
+    all_handlers: list[HandlerInfo] = []
+    seen: set[tuple[str, str]] = set()
+    for py_file in all_python_files:
+        for handler_info in find_action_handlers(py_file):
+            key = (handler_info.handler_name, handler_info.action_name)
+            if key not in seen:
+                seen.add(key)
+                all_handlers.append(handler_info)
 
     if not all_handlers:
         logger.debug(f"No action handlers found in {charm_name}")
@@ -399,7 +427,10 @@ def validate_charm(repo: pathlib.Path, entry: pathlib.Path) -> tuple[ValidationR
     )
 
     # Validate each handler
-    for handler_name, action_name, py_file in all_handlers:
+    for handler_info in all_handlers:
+        handler_name = handler_info.handler_name
+        action_name = handler_info.action_name
+
         # Check if action is defined
         if action_name not in action_defs:
             result.violations.append(Violation(
@@ -408,7 +439,7 @@ def validate_charm(repo: pathlib.Path, entry: pathlib.Path) -> tuple[ValidationR
                 param_name="N/A",
                 access_type="N/A",
                 line_number=0,
-                file_path=str(py_file.relative_to(repo)),
+                file_path=str(handler_info.observe_file.relative_to(repo)),
                 message=f"Handler exists but action '{action_name}' not defined in YAML",
             ))
             continue
@@ -416,41 +447,72 @@ def validate_charm(repo: pathlib.Path, entry: pathlib.Path) -> tuple[ValidationR
         action_def = action_defs[action_name]
         defined_params = set(action_def.params.keys())
 
-        # Extract param accesses
-        param_accesses = extract_event_params(py_file, handler_name)
+        # For non-self-method handlers (imported functions or SomeClass.method),
+        # we can't reliably locate the definition statically.
+        if not handler_info.is_self_method:
+            result.manual_review.append(ManualReview(
+                action_name=action_name,
+                line_number=0,
+                file_path=str(handler_info.observe_file.relative_to(repo)),
+                reason=f"Handler '{handler_name}' is not a self.method - may be imported, cannot validate statically",
+            ))
+            continue
+
+        # Try to find the handler definition: first in the observe file, then in all src files.
+        param_accesses, handler_found = extract_event_params(handler_info.observe_file, handler_name)
+        handler_file = handler_info.observe_file
+
+        if not handler_found:
+            for py_file in src_files:
+                if py_file == handler_info.observe_file:
+                    continue
+                param_accesses, handler_found = extract_event_params(py_file, handler_name)
+                if handler_found:
+                    handler_file = py_file
+                    break
+
+        if not handler_found:
+            result.manual_review.append(ManualReview(
+                action_name=action_name,
+                line_number=0,
+                file_path=str(handler_info.observe_file.relative_to(repo)),
+                reason=f"Handler '{handler_name}' definition not found in src/ - may be defined elsewhere",
+            ))
+            continue
 
         for access in param_accesses:
             if access.access_type == 'spread':
-                # Flag for manual review
                 result.manual_review.append(ManualReview(
                     action_name=action_name,
                     line_number=access.line_number,
-                    file_path=str(py_file.relative_to(repo)),
+                    file_path=str(handler_file.relative_to(repo)),
                     reason="Spread operator (**event.params) - cannot validate statically",
                 ))
-            elif access.param_name:
-                # Check if parameter is defined
-                if access.param_name not in defined_params:
-                    if access.access_type == 'subscript':
-                        # Error for direct access
-                        result.violations.append(Violation(
-                            action_name=action_name,
-                            handler_name=handler_name,
-                            param_name=access.param_name,
-                            access_type='[]',
-                            line_number=access.line_number,
-                            file_path=str(py_file.relative_to(repo)),
-                            message=f"Parameter '{access.param_name}' accessed but not defined in {action_def.source_file}",
-                        ))
-                    elif access.access_type == 'get':
-                        # Warning for .get() access
-                        result.warnings.append(Warning(
-                            action_name=action_name,
-                            param_name=access.param_name,
-                            line_number=access.line_number,
-                            file_path=str(py_file.relative_to(repo)),
-                            message=f"Parameter '{access.param_name}' accessed via .get() but not defined in {action_def.source_file}",
-                        ))
+            elif access.param_name and access.param_name not in defined_params:
+                # If additionalProperties is explicitly True, skip (intentional extra params)
+                if action_def.additional_properties is True:
+                    continue
+
+                if access.access_type == 'subscript':
+                    result.violations.append(Violation(
+                        action_name=action_name,
+                        handler_name=handler_name,
+                        param_name=access.param_name,
+                        access_type='[]',
+                        line_number=access.line_number,
+                        file_path=str(handler_file.relative_to(repo)),
+                        message=f"Parameter '{access.param_name}' accessed but not defined in {action_def.source_file}",
+                        additional_properties=action_def.additional_properties,
+                    ))
+                elif access.access_type == 'get':
+                    result.warnings.append(Warning(
+                        action_name=action_name,
+                        param_name=access.param_name,
+                        line_number=access.line_number,
+                        file_path=str(handler_file.relative_to(repo)),
+                        message=f"Parameter '{access.param_name}' accessed via .get() but not defined in {action_def.source_file}",
+                        additional_properties=action_def.additional_properties,
+                    ))
 
     return result, None
 
@@ -512,14 +574,20 @@ def report(results: list[ValidationResult], console: rich.console.Console, skip_
         table.add_column("Action", style="yellow")
         table.add_column("Parameter", style="magenta")
         table.add_column("Location", style="green")
+        table.add_column("additionalProperties", style="white")
 
         for result in results:
             for v in result.violations:
+                add_props = (
+                    "not set" if v.additional_properties is None
+                    else str(v.additional_properties)
+                )
                 table.add_row(
                     result.charm_name,
                     v.action_name,
                     v.param_name,
                     f"{v.file_path}:{v.line_number}",
+                    add_props,
                 )
 
         console.print(table)
@@ -534,21 +602,27 @@ def report(results: list[ValidationResult], console: rich.console.Console, skip_
         table.add_column("Action", style="yellow")
         table.add_column("Parameter", style="magenta")
         table.add_column("Location", style="green")
+        table.add_column("additionalProperties", style="white")
 
         for result in results:
             for w in result.warnings:
+                add_props = (
+                    "not set" if w.additional_properties is None
+                    else str(w.additional_properties)
+                )
                 table.add_row(
                     result.charm_name,
                     w.action_name,
                     w.param_name,
                     f"{w.file_path}:{w.line_number}",
+                    add_props,
                 )
 
         console.print(table)
 
     # Manual review table
     if total_manual_review > 0:
-        console.print("\n[bold blue]MANUAL REVIEW: Spread operator usage[/bold blue]")
+        console.print("\n[bold blue]MANUAL REVIEW: Handlers and spread operators requiring manual inspection[/bold blue]")
         console.print("═" * 80)
 
         table = rich.table.Table(show_header=True, header_style="bold blue")
@@ -604,13 +678,26 @@ def main(cache_folder, strict, output_csv, verbose):
     }
 
     for repo in iter_repositories(cache_path):
-        # Find charm entry point
-        entry = repo / "src" / "charm.py"
-        if not entry.exists():
+        # Use the same entry point resolution as iter_entries() in helpers.py
+        entry = "src/charm.py"
+        if (repo / "charmcraft.yaml").exists():
+            try:
+                with (repo / "charmcraft.yaml").open() as f:
+                    charmcraft_data = yaml.safe_load(f) or {}
+                entry = (
+                    charmcraft_data.get("parts", {})
+                    .get("charm", {})
+                    .get("charm-entrypoint", entry)
+                )
+            except Exception as e:
+                logger.debug("Failed to read charmcraft.yaml entrypoint for %s: %s", repo, e)
+
+        # Skip repos with no Python source at all
+        if not (repo / entry).exists() and next(repo.glob("src/**/*.py"), None) is None:
             continue
 
         skip_stats["total"] += 1
-        result, skip_reason = validate_charm(repo, entry)
+        result, skip_reason = validate_charm(repo)
 
         if skip_reason:
             skip_stats[skip_reason] = skip_stats.get(skip_reason, 0) + 1
@@ -623,7 +710,7 @@ def main(cache_folder, strict, output_csv, verbose):
     # Output CSV if requested
     if output_csv:
         writer = csv.writer(output_csv)
-        writer.writerow(["charm", "action", "parameter", "access_type", "line", "file", "severity", "defined_params"])
+        writer.writerow(["charm", "action", "parameter", "access_type", "line", "file", "severity", "additionalProperties"])
 
         for result in results:
             for v in result.violations:
@@ -635,7 +722,7 @@ def main(cache_folder, strict, output_csv, verbose):
                     v.line_number,
                     v.file_path,
                     "error",
-                    "",  # Could add defined params here
+                    "" if v.additional_properties is None else v.additional_properties,
                 ])
 
             for w in result.warnings:
@@ -647,7 +734,7 @@ def main(cache_folder, strict, output_csv, verbose):
                     w.line_number,
                     w.file_path,
                     "warning",
-                    "",
+                    "" if w.additional_properties is None else w.additional_properties,
                 ])
 
         console.print(f"\n[green]CSV output written to {output_csv.name}[/green]")


### PR DESCRIPTION
Using a property/param that isn't defined is fine, as long as `additionalProperties` is set to `False` (or, before Juju 4, not set, as `False` was the default).

Add a report that summarises whether any of the charms are doing this, so that we can proactively open PRs to be explicit if required.