### PR TITLE
feat: allow specifying a custom poetry executable

### DIFF
--- a/tools/super-tox.py
+++ b/tools/super-tox.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 @dataclasses.dataclass
 class Settings:
     executable: str
+    poetry_executable: str
     mode: typing.Literal["local", "lxd", "lxd-per-tox"]
     lxd_name: str
     lxd_image_alias: str
@@ -154,7 +155,7 @@ def patch_ops(location: pathlib.Path):
         adjusted["dependencies"].append(f"\nops = {ops}")
         # Some charms require running poetry lock after this change.
         if "poetry" in adjusted.get("tool", {}):
-            subprocess.run(["poetry", "lock"], cwd=location, stdout=subprocess.PIPE)
+            subprocess.run([*shlex.split(settings.poetry_executable), "lock"], cwd=location, stdout=subprocess.PIPE)
         try:
             yield pyproject
         finally:
@@ -472,6 +473,7 @@ def fixme(f):
 @click.option("--verbose/--no-verbose", default=False, help="additional output")
 @click.option("--sample", default=0, help="try to run only this many repositories")
 @click.option("--executable", default="tox")
+@click.option("--poetry-executable", default="poetry")
 @click.command()
 def main(
     cache_folder: str,


### PR DESCRIPTION
I don't have `poetry` installed locally, but `super-tox` needs it to be able to patch the dependencies. This PR allows specifying a custom `poetry` executable in the same way that a custom `tox` can be provided. (In my case, I would provide `uvx poetry`).